### PR TITLE
Switch from DotNetZip to System.IO.Compression

### DIFF
--- a/Blackberry2droid/Blackberry2droid.csproj
+++ b/Blackberry2droid/Blackberry2droid.csproj
@@ -37,9 +37,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetZip, Version=1.11.0.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetZip.1.11.0\lib\net20\DotNetZip.dll</HintPath>
-    </Reference>
     <Reference Include="Mediaburst.Text, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Mediaburst.Text.GSMEncoding.1.0\lib\net40\Mediaburst.Text.dll</HintPath>
     </Reference>
@@ -50,6 +47,8 @@
     <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression.FileSystem" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Form1.cs">

--- a/Blackberry2droid/IPD.cs
+++ b/Blackberry2droid/IPD.cs
@@ -88,7 +88,7 @@ namespace Blackberry2droid
             {
                 int dThisDatabaseId = Convert.ToInt32( xmlNode.Attributes["uid"].Value );
                 dDatabaseId = dThisDatabaseId;
-                szZipPath = "Databases\\" + dThisDatabaseId + ".dat";
+                szZipPath = "Databases/" + dThisDatabaseId + ".dat";
                 break;                  
             }
             return szZipPath;

--- a/Blackberry2droid/IPD.cs
+++ b/Blackberry2droid/IPD.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.IO;
 using System.Xml;
-using Ionic.Zip;
+using System.IO.Compression;
 
 
 namespace Blackberry2droid
@@ -41,25 +41,33 @@ namespace Blackberry2droid
         /// <param name="szRequiredDatabase"></param>
         public ExtractBBBFile(string szFilePath, string szRequiredDatabase)
         {
+            szTempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(szTempDir); // Ensure directory exists
+
             string szZipPath = string.Empty;
-            szTempDir = Path.Combine( Path.GetTempPath(), Path.GetRandomFileName() );
-            
-            using (ZipFile objZipFile = ZipFile.Read(szFilePath))
+
+            using (ZipArchive archive = ZipFile.OpenRead(szFilePath))
             {
-                // Extract Manifest file.
-                ZipEntry objZipManifest = objZipFile["Manifest.xml"];
-                objZipManifest.Extract(szTempDir, ExtractExistingFileAction.OverwriteSilently);
-                
-                // Get the path inside the ZIP FILE to the required database.
-                szZipPath = getDatabaseUriFromManifest(szRequiredDatabase, Path.Combine(szTempDir, "Manifest.xml"));
+                // Extract Manifest.xml
+                ZipArchiveEntry manifestEntry = archive.GetEntry("Manifest.xml");
+                if (manifestEntry != null)
+                {
+                    string manifestPath = Path.Combine(szTempDir, "Manifest.xml");
+                    manifestEntry.ExtractToFile(manifestPath, overwrite: true);
 
-                // Extract databse file.
-                ZipEntry objZipDatabase = objZipFile[szZipPath];
-                objZipDatabase.Extract(szTempDir, ExtractExistingFileAction.OverwriteSilently);
-                szDatabasePath = Path.Combine(szTempDir, szZipPath);
-                return;
+                    // Get path to required database inside the ZIP
+                    szZipPath = getDatabaseUriFromManifest(szRequiredDatabase, manifestPath);
+
+                    // Extract database file
+                    ZipArchiveEntry databaseEntry = archive.GetEntry(szZipPath);
+                    if (databaseEntry != null)
+                    {
+                        szDatabasePath = Path.Combine(szTempDir, szZipPath);
+                        Directory.CreateDirectory(Path.GetDirectoryName(szDatabasePath)); // Create subfolders if needed
+                        databaseEntry.ExtractToFile(szDatabasePath, overwrite: true);
+                    }
+                }
             }
-
         }
         
 

--- a/Blackberry2droid/Properties/AssemblyInfo.cs
+++ b/Blackberry2droid/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.3.0")]
-[assembly: AssemblyFileVersion("1.0.3.0")]
+[assembly: AssemblyVersion("1.0.4.0")]
+[assembly: AssemblyFileVersion("1.0.4.0")]

--- a/Blackberry2droid/packages.config
+++ b/Blackberry2droid/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetZip" version="1.11.0" targetFramework="net47" />
   <package id="Mediaburst.Text.GSMEncoding" version="1.0" targetFramework="net47" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 # Blackberry2Droid
 
-This is the C# (.Net 4.7) sourcecode for [Blackberry2Droid](https://damn.technology/blackberry2droid), a free application that converts Blackberry IPD/BBB files to an XML format supported by "SMS Backup and Restore".
+This is the C# (.Net 4.7) sourcecode for Blackberry2Droid, a free application that converts Blackberry IPD/BBB files to an XML format supported by "SMS Backup and Restore".
 
 ## Dependencies
 
 | Dependency    | Licence       |
 | ------------- | ------------- |
-| [Ionic ZIP library](https://dotnetzip.codeplex.com/) | Microsoft Public License (Ms-PL) |
 | [Clockwork GSM Encoding library](https://github.com/mediaburst/.NET-GSM-Encoding) | MIT Licence |
 
 ## License


### PR DESCRIPTION
Addresses CVE-2024-48510 by moving to System.IO.Compression and removing the dependency on DotNetZip